### PR TITLE
fix(renderer): provide `nuxt.options`

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -6,6 +6,7 @@ export function initVueRenderer () {
   fixConfig(options)
 
   const nuxt = {
+    options,
     hook: () => {},
     callHook: () => {}
   }


### PR DESCRIPTION
Fixes nuxt/nuxt.js#7752 and more potential bugs if one is using `serverContext.nuxt.options`. 